### PR TITLE
Create the private directory when compiling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ ifneq ($(OS),Windows_NT)
 endif
 
 priv/lib_mcrypt.so: clean
+	@mkdir -p priv
 	@$(CC) $(CFLAGS) -shared $(LDFLAGS) -o $@ \
 		c_src/mcrypt_nif.c \
 		-lmcrypt


### PR DESCRIPTION
Right now there is an error when running `mix compile.mcrypt`, this
directory is taking for granted. This change creates the directory if it
doesn't exist when compiling.
